### PR TITLE
Quote - Add Timestamp

### DIFF
--- a/docs/Quote.md
+++ b/docs/Quote.md
@@ -11,5 +11,6 @@ Name | Type | Description | Notes
 **pc** | **Number** | Previous close price | [optional] 
 **d** | **Number** | Change | [optional] 
 **dp** | **Number** | Percent change | [optional] 
+**t** | **Number** | Reference UNIX timestamp in ms. | [optional] 
 
 

--- a/src/model/Quote.js
+++ b/src/model/Quote.js
@@ -68,6 +68,9 @@ class Quote {
             if (data.hasOwnProperty('dp')) {
                 obj['dp'] = ApiClient.convertToType(data['dp'], 'Number');
             }
+            if (data.hasOwnProperty('t')) {
+                obj['t'] = ApiClient.convertToType(data['t'], 'Number');
+            }
         }
         return obj;
     }
@@ -117,6 +120,11 @@ Quote.prototype['d'] = undefined;
  */
 Quote.prototype['dp'] = undefined;
 
+/**
+ * Timestamp
+ * @member {Number} t
+ */
+ Quote.prototype['t'] = undefined;
 
 
 

--- a/test/model/Quote.spec.js
+++ b/test/model/Quote.spec.js
@@ -84,6 +84,12 @@
       //expect(instance).to.be();
     });
 
+    it('should have the property t (base name: "t")', function() {
+      // uncomment below and update the code to test the property t
+      //var instane = new finnhub.Quote();
+      //expect(instance).to.be();
+    });
+
   });
 
 }));


### PR DESCRIPTION
The Finnhub API provides a timestamp attribute `t` from the Stock Quote endpoint. While the documentation at [https://finnhub.io/docs/api/quote](https://finnhub.io/docs/api/quote) does not explicitly state it, the API returns it and the sample data show it.

This PR adds the attribute to the model.