### PR TITLE
Add missing 't' property handling to Quote.js

### DIFF
--- a/src/model/Quote.js
+++ b/src/model/Quote.js
@@ -68,6 +68,9 @@ class Quote {
             if (data.hasOwnProperty('dp')) {
                 obj['dp'] = ApiClient.convertToType(data['dp'], 'Number');
             }
+            if (data.hasOwnProperty('t')) {
+                obj['t'] = ApiClient.convertToType(data['t'], 'Number');
+            }
         }
         return obj;
     }
@@ -116,6 +119,12 @@ Quote.prototype['d'] = undefined;
  * @member {Number} dp
  */
 Quote.prototype['dp'] = undefined;
+
+/**
+ * Timestamp
+ * @member {Number} t
+ */
+Quote.prototype['t'] = undefined;
 
 
 


### PR DESCRIPTION
Added the 't' property to the Quote model, which was previously omitted. Included logic to handle the 't' property, converting it to a number, and defined it as a timestamp in the Quote model.